### PR TITLE
Create SCC before creating the deployment

### DIFF
--- a/installopa/admission-controller.yaml
+++ b/installopa/admission-controller.yaml
@@ -39,6 +39,38 @@ subjects:
   name: system:serviceaccounts:opa
   apiGroup: rbac.authorization.k8s.io
 ---
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: opa-scc
+  namespace: opa
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+- '*'
+allowedUnsafeSysctls:
+- '*'
+defaultAddCapabilities: []
+requiredDropCapabilities: []
+readOnlyRootFilesystem: false
+# allowedProcMountTypes: runtime/default
+priority: 1
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+users:
+- system:serviceaccount:opa:default
+volumes:
+- '*'
+---
 kind: Service
 apiVersion: v1
 metadata:
@@ -148,35 +180,3 @@ data:
         reason != ""
     }
     else = {"allowed": true, "uid": uid}
----
-kind: SecurityContextConstraints
-apiVersion: security.openshift.io/v1
-metadata:
-  name: opa-scc
-  namespace: opa
-allowHostDirVolumePlugin: true
-allowHostIPC: true
-allowHostNetwork: true
-allowHostPID: true
-allowHostPorts: true
-allowPrivilegeEscalation: true
-allowPrivilegedContainer: true
-allowedCapabilities:
-- '*'
-allowedUnsafeSysctls:
-- '*'
-defaultAddCapabilities: []
-requiredDropCapabilities: []
-readOnlyRootFilesystem: false
-# allowedProcMountTypes: runtime/default
-priority: 1
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-seccompProfiles:
-- '*'
-users:
-- system:serviceaccount:opa:default
-volumes:
-- '*'


### PR DESCRIPTION
With the existing sequence, the pod goes to crashloopback state since it can't bind the port. The reason is, that deployment is created prior to the SCC due to which, when the pod is created, we don't have the SCC created. If we just delete the pod, the next time pod comes up without any issues. If we create the SCC first, this works without any issues. Hence, moving the SCC template before creating the deployment object.